### PR TITLE
feat: improve API of alemat

### DIFF
--- a/src/buf_writer.rs
+++ b/src/buf_writer.rs
@@ -294,7 +294,7 @@ impl Writer for BufMathMlWriter {
         if radical.is_square() {
             self.write_str("</msqrt>")
         } else {
-            self.write_num(&Num::from(radical.index()))?;
+            self.write_elements(radical.index())?;
             self.write_str("</mroot>")
         }
     }

--- a/src/default_renderer.rs
+++ b/src/default_renderer.rs
@@ -5,7 +5,7 @@ use crate::{
     elements::{
         grouping::{ActionAttr, Prescripts},
         scripted::UnderOverAttr,
-        AnnotationAttr, AnnotationContent, FracAttr, Num, OperatorAttr, PaddedAttr, SpaceAttr,
+        AnnotationAttr, AnnotationContent, FracAttr, OperatorAttr, PaddedAttr, SpaceAttr,
         TableAttr, TableCellAttr,
     },
     DisplayAttr, Element, MathMlAttr, Renderer,
@@ -244,7 +244,7 @@ impl Renderer for MathMlFormatter {
         if radical.is_square() {
             Ok(format!(r#"<msqrt {attr}>{content}</msqrt>"#))
         } else {
-            let index = self.render_num(&Num::from(radical.index()))?;
+            let index = self.render_elements(radical.index())?;
 
             Ok(format!(r#"<mroot {attr}>{content}{index}</mroot>"#))
         }

--- a/src/elements.rs
+++ b/src/elements.rs
@@ -155,6 +155,24 @@ impl DerefMut for Elements {
     }
 }
 
+impl FromIterator<Element> for Elements {
+    fn from_iter<T: IntoIterator<Item = Element>>(iter: T) -> Self {
+        let inner = iter.into_iter().collect();
+        Self(inner)
+    }
+}
+
+impl FromIterator<Elements> for Elements {
+    fn from_iter<T: IntoIterator<Item = Elements>>(iter: T) -> Self {
+        let mut elements = Self::default();
+        for mut el in iter.into_iter() {
+            elements.append(&mut el);
+        }
+
+        elements
+    }
+}
+
 impl IntoElements for Elements {
     fn into_elements(self) -> Elements {
         self

--- a/src/elements/mfrac.rs
+++ b/src/elements/mfrac.rs
@@ -4,6 +4,7 @@ use crate::attributes::Attribute;
 use crate::markers::{Init, Uninit};
 use crate::{Element, Elements};
 
+use super::grouping::Row;
 use super::IntoElements;
 
 /// An attribute of `mfrac` element. Either one of the global [`Attribute`]s, or `linethickness`
@@ -102,6 +103,12 @@ pub struct FracBuilder<N, D> {
 impl<N, D> FracBuilder<N, D> {
     /// Add or overwrite the numerator to the `mfrac` element.
     pub fn num(self, num: impl IntoElements) -> FracBuilder<Init, D> {
+        let mut num = num.into_elements();
+
+        if num.len() > 1 {
+            num = Row::from(num).into_elements();
+        }
+
         FracBuilder {
             num: Some(num.into_elements()),
             denom: self.denom,
@@ -112,6 +119,12 @@ impl<N, D> FracBuilder<N, D> {
 
     /// Add or overwrite the denominator to the `mfrac` element.
     pub fn denom(self, denom: impl IntoElements) -> FracBuilder<N, Init> {
+        let mut denom = denom.into_elements();
+
+        if denom.len() > 1 {
+            denom = Row::from(denom).into_elements();
+        }
+
         FracBuilder {
             num: self.num,
             denom: Some(denom.into_elements()),

--- a/src/elements/mo/dict.rs
+++ b/src/elements/mo/dict.rs
@@ -166,7 +166,7 @@ impl Operator {
         Self::from("\u{003C}")
     }
 
-    pub fn rt() -> Self {
+    pub fn gt() -> Self {
         Self::from("\u{003E}")
     }
 

--- a/src/elements/mrow.rs
+++ b/src/elements/mrow.rs
@@ -30,6 +30,16 @@ impl<const N: usize, I: Into<Element>> From<[I; N]> for Row {
 }
 
 impl Row {
+    /// Add a single element.
+    pub fn add_element(&mut self, el: impl Into<Element>) {
+        self.children.push(el.into());
+    }
+
+    /// Add multiple elements.
+    pub fn add_elements(&mut self, el: impl IntoElements) {
+        self.children.append(&mut el.into_elements());
+    }
+
     /// Add attributes.
     pub fn add_attr<I, A>(&mut self, attr: I)
     where

--- a/src/elements/mtable.rs
+++ b/src/elements/mtable.rs
@@ -38,7 +38,7 @@ pub enum TableAttr {
 /// stylesheet must contain the following rules in order to implement these properties:
 ///
 /// The `mtable` accepts the global [`Attribute`]s.
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Debug, Default, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Table {
     rows: Vec<TableRow>,
     /// The `mtable` accepts the global [`Attribute`]s.
@@ -162,7 +162,7 @@ macro_rules! table {
 ///   display: table-row;
 /// }
 /// ```
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Debug, Default, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub struct TableRow {
     /// Table cells (`mtd`) of this table row.
     cells: Vec<TableCell>,
@@ -308,7 +308,7 @@ impl From<Attribute> for TableCellAttr {
 ///   padding: 0.5ex 0.4em;
 /// }
 /// ```
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Debug, Default, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub struct TableCell {
     children: Elements,
     attr: Vec<TableCellAttr>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,20 +1,22 @@
 #![warn(missing_docs)]
 //! Library for type-safe building of MathML (core) markup.
 
-pub mod attributes;
 mod buf_writer;
 mod default_renderer;
+mod to_mathml;
+use elements::IntoElements;
+
+pub mod attributes;
 pub mod elements;
 pub mod markers;
-mod to_mathml;
 
 pub use attributes::Attribute;
 pub use buf_writer::BufMathMlWriter;
 pub use default_renderer::MathMlFormatter;
-pub(crate) use elements::element_from_type;
-use elements::IntoElements;
 pub use elements::{Element, Elements};
 pub use to_mathml::*;
+
+pub(crate) use elements::element_from_type;
 
 /// Specifies how the enclosed MathML markup should be rendered.
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]

--- a/tests/others/mo.rs
+++ b/tests/others/mo.rs
@@ -6,3 +6,10 @@ fn operator_product() {
 
     crate::snap_test!(out, name: "operator_product");
 }
+
+#[test]
+fn operator_iff() {
+    let out = MathMl::with_content(Operator::iff()).render();
+
+    crate::snap_test!(out, name: "operator_iff");
+}

--- a/tests/radicals/mod.rs
+++ b/tests/radicals/mod.rs
@@ -7,7 +7,7 @@ use alemat::{
 fn sqrt() {
     let output = MathMl::with_content(
         Radical::builder()
-            .index("2")
+            .index(Num::from(2))
             .content(alemat::children![
                 Num::from(1),
                 Operator::from("+"),
@@ -28,7 +28,7 @@ fn sqrt() {
 fn root() {
     let output = MathMl::with_content(
         Radical::builder()
-            .index("3")
+            .index(Num::from(3))
             .content(alemat::children![
                 Num::from(1),
                 Operator::from("+"),
@@ -43,4 +43,29 @@ fn root() {
     .render();
 
     crate::snap_test!(output, name: "radicals_root");
+}
+
+#[test]
+fn root_expr() {
+    let output = MathMl::with_content(
+        Radical::builder()
+            .index(alemat::children![
+                Ident::from("n"),
+                Operator::plus(),
+                Num::from(1)
+            ])
+            .content(alemat::children![
+                Num::from(1),
+                Operator::from("+"),
+                SubSup::builder()
+                    .base(Ident::from("n"))
+                    .subscript(Num::from(2))
+                    .supscript(Num::from(3))
+                    .build(),
+            ])
+            .build(),
+    )
+    .render();
+
+    crate::snap_test!(output, name: "radicals_root_expr");
 }

--- a/tests/snapshots/operator_iff.snap
+++ b/tests/snapshots/operator_iff.snap
@@ -1,0 +1,10 @@
+---
+source: tests/others/mo.rs
+expression: input
+---
+<math>
+  <mo>
+    ⇔
+  </mo>
+</math>
+

--- a/tests/snapshots/radicals_root_expr.snap
+++ b/tests/snapshots/radicals_root_expr.snap
@@ -1,0 +1,39 @@
+---
+source: tests/radicals/mod.rs
+expression: input
+---
+<math>
+  <mroot>
+    <mrow>
+      <mn>
+        1
+      </mn>
+      <mo>
+        +
+      </mo>
+      <msubsup>
+        <mi>
+          n
+        </mi>
+        <mn>
+          2
+        </mn>
+        <mn>
+          3
+        </mn>
+      </msubsup>
+    </mrow>
+    <mrow>
+      <mi>
+        n
+      </mi>
+      <mo>
+        +
+      </mo>
+      <mn>
+        1
+      </mn>
+    </mrow>
+  </mroot>
+</math>
+


### PR DESCRIPTION
In this PR various improvements to API, some of them:

* Make `Elements` collectable from iterators by implementing the `FromIterator` trait. 
* Make it possible to use arbitrary MathMl expressions for index of a `mroot` element. 
* Derive `Default` for `Table`, `TableRow` and `TableCell`
* Ensure that numerator and denominator of `mfrac` are single element (wrap multiple elements in `mrow`)