### PR TITLE
feat: add possibility to map content of `MathMl`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -69,6 +69,13 @@ impl MathMl {
         &self.content
     }
 
+    /// Map the content contained in [`MathMl`].
+    ///
+    /// Useful, for example, when wrapping the content in [`elements::Row`] is desired.
+    pub fn map(&mut self, f: impl FnOnce(Elements) -> Elements) {
+        self.content = f(std::mem::take(&mut self.content));
+    }
+
     /// Get a reference to all attributes of the `math` element.
     pub fn attributes(&self) -> &[MathMlAttr] {
         &self.attr

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -72,8 +72,24 @@ impl MathMl {
     /// Map the content contained in [`MathMl`].
     ///
     /// Useful, for example, when wrapping the content in [`elements::Row`] is desired.
-    pub fn map(&mut self, f: impl FnOnce(Elements) -> Elements) {
-        self.content = f(std::mem::take(&mut self.content));
+    ///
+    /// # Example
+    /// ```ignore
+    /// let out = MathMl::with_content(
+    ///     Frac::builder()
+    ///         .num(Ident::from("x"))
+    ///         .denom(Ident::from("y"))
+    ///         .build(),
+    /// )
+    /// .map(Row::from)
+    /// .render();
+    /// ```
+    pub fn map<T>(mut self, f: impl FnOnce(Elements) -> T) -> Self
+    where
+        T: IntoElements,
+    {
+        self.content = f(self.content).into_elements();
+        self
     }
 
     /// Get a reference to all attributes of the `math` element.

--- a/tests/others/mapping.rs
+++ b/tests/others/mapping.rs
@@ -1,0 +1,18 @@
+use alemat::{
+    elements::{grouping::Row, Frac, Ident},
+    MathMl,
+};
+
+#[test]
+fn map_in_row() {
+    let out = MathMl::with_content(
+        Frac::builder()
+            .num(Ident::from("x"))
+            .denom(Ident::from("y"))
+            .build(),
+    )
+    .map(Row::from)
+    .render();
+
+    crate::snap_test!(out, name: "others_map_in_row");
+}

--- a/tests/others/mod.rs
+++ b/tests/others/mod.rs
@@ -1,4 +1,5 @@
 mod annotation;
+mod mapping;
 mod mfrac;
 mod mi;
 mod mn;

--- a/tests/snapshots/others_map_in_row.snap
+++ b/tests/snapshots/others_map_in_row.snap
@@ -1,0 +1,17 @@
+---
+source: tests/others/mapping.rs
+expression: input
+---
+<math>
+  <mrow>
+    <mfrac>
+      <mi>
+        x
+      </mi>
+      <mi>
+        y
+      </mi>
+    </mfrac>
+  </mrow>
+</math>
+


### PR DESCRIPTION
This makes it possible to change content of `MathMl` struct, including wrapping it in some element like `mrow` etc. 