### PR TITLE
feat: add constructor for the norm (`∥`) operator

### DIFF
--- a/src/elements/mo/dict.rs
+++ b/src/elements/mo/dict.rs
@@ -416,6 +416,11 @@ impl Operator {
         Self::from("\u{007C}")
     }
 
+    /// Create a '&#x2225;' operator.
+    pub fn norm() -> Self {
+        Self::from("\u{2225}")
+    }
+
     /// Create a '&#x005E;' operator.
     pub fn hat() -> Self {
         Self::from("\u{005E}")


### PR DESCRIPTION
In this PR we introduce a helper constructor for the Norm operator (`∥`).
